### PR TITLE
Fix Demo warning

### DIFF
--- a/iOS Example/Source/Base.lproj/Main.storyboard
+++ b/iOS Example/Source/Base.lproj/Main.storyboard
@@ -83,7 +83,7 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="cZr-2G-mbD">
-                        <barButtonItem key="rightBarButtonItem" title="Horizontal Scroll" style="plain" id="fms-Ek-KSO">
+                        <barButtonItem key="rightBarButtonItem" title="Horizontal Scroll" id="fms-Ek-KSO">
                             <switch key="customView" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="zF8-Bv-g8k">
                                 <rect key="frame" x="310" y="6" width="51" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>


### PR DESCRIPTION
#### Summary

This PR Fixed Demo App warning with Stroyboard. 🔧 

<img width="260" alt="ss" src="https://cloud.githubusercontent.com/assets/731436/23402839/aa98c35e-fdf0-11e6-8db3-e71b6548d3b2.png">


#### See also
http://stackoverflow.com/questions/10945859/plain-style-unsupported-in-a-navigation-item-warning-with-my-customized-bar-bu
