### PR TITLE
Make AnimatedCollectionViewLayout class open so it can be subclassed

### DIFF
--- a/Source/AnimatedCollectionViewLayout.swift
+++ b/Source/AnimatedCollectionViewLayout.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 /// A `UICollectionViewFlowLayout` subclass enables custom transitions between cells.
-public class AnimatedCollectionViewLayout: UICollectionViewFlowLayout {
+open class AnimatedCollectionViewLayout: UICollectionViewFlowLayout {
     
     /// The animator that would actually handle the transitions.
     public var animator: LayoutAttributesAnimator?


### PR DESCRIPTION
"Public" is not able to be subclassed outside the module. This would allow you to override things like finalLayoutAttributesForDisappearingItem and initialLayoutAttributesForAppearingItem to customize the appearing and dismissing of cells. 

Let me know if there's a better way to do this.